### PR TITLE
Enable upload support for Contrast Assess Findings XML

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -4,13 +4,13 @@ description:
   automatically fix issues found.
 
 inputs:
-  pixee-api-url: 
+  pixee-api-url:
     description: The base URL of the Pixee API
     default: https://api.pixee.ai
   tool:
     description: >
       The supported code scanning tool that produced the results being uploaded.
-      Allowed values: 'sonar', 'codeql', 'semgrep', 'defectdojo'
+      Allowed values: 'sonar', 'codeql', 'semgrep', 'defectdojo', 'contrast'
     required: true
   file:
     description: Path to the tool's results file to share with Pixeebot.

--- a/src/action.ts
+++ b/src/action.ts
@@ -17,6 +17,11 @@ export async function run() {
   const tool = getTool();
 
   switch(tool){
+    case "contrast":
+      const contrastFile = await fetchOrLocateContrastResultsFile();
+      await uploadInputFile(tool, contrastFile);
+      core.info(`Uploaded ${contrastFile} to Pixeebot for analysis`);
+      break;
     case "defectdojo":
       const file = await fetchOrLocateDefectDojoResultsFile();
       await uploadInputFile(tool, file);
@@ -34,7 +39,7 @@ export async function run() {
     default:
       throw new Error("Action not implemented for tool: " + tool);
   }
-  
+
   const { prNumber } = getGitHubContext();
   if (prNumber) {
     await triggerPrAnalysis(prNumber);
@@ -49,6 +54,15 @@ async function fetchOrLocateDefectDojoResultsFile() {
 
 
   return fetchOrLocateResultsFile("defectdojo", results, fileName);
+}
+
+async function fetchOrLocateContrastResultsFile() {
+  let file = core.getInput("file");
+  if (file !== "") {
+    return file;
+  }
+
+  throw new Error("Contrast requires a file to be provided");
 }
 
 async function fetchOrLocateSonarResultsFile(resultType : SONAR_RESULT) {

--- a/src/inputs.ts
+++ b/src/inputs.ts
@@ -1,9 +1,9 @@
 import * as core from "@actions/core";
 import { UserError } from "./errors";
 
-export type Tool = "sonar" | "codeql" | "semgrep" | "appscan" | "defectdojo";
+export type Tool = "sonar" | "codeql" | "semgrep" | "appscan" | "defectdojo" | "contrast";
 
-export type TOOL_PATH = "sonar_issues" | "sonar_hotspots" | "codeql" | "semgrep" | "appscan" | "defectdojo";
+export type TOOL_PATH = "sonar_issues" | "sonar_hotspots" | "codeql" | "semgrep" | "appscan" | "defectdojo" | "contrast";
 
 /**
  * Helper function to get the selected tool from the action's inputs.
@@ -26,4 +26,4 @@ function validateTool(tool: Tool) {
   }
 }
 
-const VALID_TOOLS: Tool[] = ["sonar", "codeql", "semgrep", "appscan", "defectdojo"];
+const VALID_TOOLS: Tool[] = ["sonar", "codeql", "semgrep", "appscan", "defectdojo", "contrast"];


### PR DESCRIPTION
* For now this supports uploads of Assess Findings XML files that are available on disk
* Support for retrieving findings from the Contrast API will be forthcoming
