### PR TITLE
✨ Add Support for Uploading Local Tool Results Instead of Fetching Results

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ Detailed description of the inputs exposed by the
     tool:
 
     # Token for authenticating requests to Sonar.
-    # Required, when tool is "sonar" and "file" has not been set. Only required for private repository.
+    # Required, when tool is "sonar". Only required for private repository.
     sonar-token:
 
     # Key identifying the Sonar component to be analyzed. Only necessary if deviating from Sonar's established convention.
@@ -142,8 +142,9 @@ Detailed description of the inputs exposed by the
     # Default: https://api.pixee.ai
     pixee-api-url:
 
-    # Path to the tool's results file to upload to Pixeebot. This does not apply to Sonar integration, because the action retrieves the results directly from Sonar.
-    # Required, when `tool` is not "sonar"
+    # Path to the tool's results file to upload to Pixeebot.
+    # This is required when using a `tool` that does not support automatically fetching results. Contrast, Sonar, and DefectDojo integrations support automatically fetching results. When this input is used with those tools, the given file will be uploaded _instead of_ automatically fetching results.
+    # Note: for Sonar results, the tool must be `sonar_hotspots` or `sonar_issues` instead of `sonar` when using this input.
     file:
 ```
 

--- a/__tests__/sonar.test.ts
+++ b/__tests__/sonar.test.ts
@@ -37,7 +37,7 @@ describe("sonar", () => {
       path,
       queryParamKey: "componentKeys",
       pageSize: 500,
-      page: 1
+      page: 1,
     });
 
     expect(result).toBe(
@@ -58,7 +58,7 @@ describe("sonar", () => {
       path,
       queryParamKey: "componentKeys",
       pageSize: 500,
-      page: 1
+      page: 1,
     });
 
     expect(result).toBe(
@@ -74,7 +74,7 @@ describe("sonar", () => {
       path,
       queryParamKey: "projectKey",
       pageSize: 500,
-      page: 1
+      page: 1,
     });
 
     expect(result).toBe(
@@ -97,7 +97,7 @@ describe("sonar", () => {
       path,
       queryParamKey: "componentKeys",
       pageSize: 500,
-      page: 1
+      page: 1,
     });
 
     expect(result).toBe(
@@ -120,7 +120,7 @@ describe("sonar", () => {
       path,
       queryParamKey: "componentKeys",
       pageSize: 500,
-      page: 1
+      page: 1,
     });
 
     expect(result).toBe(
@@ -144,7 +144,7 @@ describe("sonar", () => {
       path,
       queryParamKey: "projectKey",
       pageSize: 500,
-      page: 1
+      page: 1,
     });
 
     expect(result).toBe(

--- a/src/inputs.ts
+++ b/src/inputs.ts
@@ -3,6 +3,8 @@ import { UserError } from "./errors";
 
 export type Tool =
   | "sonar"
+  | "sonar_issues"
+  | "sonar_hotspots"
   | "codeql"
   | "semgrep"
   | "appscan"
@@ -43,6 +45,8 @@ function validateTool(tool: Tool) {
 
 const VALID_TOOLS: Tool[] = [
   "sonar",
+  "sonar_issues",
+  "sonar_hotspots",
   "codeql",
   "semgrep",
   "appscan",

--- a/src/pixee-platform.ts
+++ b/src/pixee-platform.ts
@@ -8,10 +8,10 @@ import { getGitHubContext, getRepositoryInfo } from "./github";
 export async function uploadInputFiles(tool: TOOL_PATH, files: Array<string>) {
   const form = new FormData();
 
-  const path = require('path');
+  const path = require("path");
 
   // Append each file to the form data
-  files.forEach(file => {
+  files.forEach((file) => {
     form.append("files", fs.readFileSync(file), path.basename(file));
   });
 

--- a/src/sonar.ts
+++ b/src/sonar.ts
@@ -23,7 +23,7 @@ type QUERY_PARAM_KEY = "componentKeys" | "projectKey";
 export async function retrieveSonarIssues(
   sonarInputs: SonarInputs,
   pageSize: number,
-  page: number
+  page: number,
 ): Promise<SonarSearchIssuesResult> {
   const path = "api/issues/search";
   const url = buildSonarUrl({
@@ -31,7 +31,7 @@ export async function retrieveSonarIssues(
     path,
     queryParamKey: "componentKeys",
     pageSize,
-    page
+    page,
   });
   return retrieveSonarResults(sonarInputs, url, "issues");
 }
@@ -39,7 +39,7 @@ export async function retrieveSonarIssues(
 export async function retrieveSonarHotspots(
   sonarInputs: SonarInputs,
   pageSize: number,
-  page: number
+  page: number,
 ): Promise<SonarSearchHotspotResult> {
   const path = "api/hotspots/search";
   const url = buildSonarUrl({
@@ -47,7 +47,7 @@ export async function retrieveSonarHotspots(
     path,
     queryParamKey: "projectKey",
     pageSize,
-    page
+    page,
   });
   return retrieveSonarResults(sonarInputs, url, "hotspots");
 }
@@ -57,7 +57,7 @@ export function buildSonarUrl({
   path,
   queryParamKey,
   pageSize,
-  page
+  page,
 }: {
   sonarInputs: SonarInputs;
   path: string;


### PR DESCRIPTION
When using the `file` input with any of the tools that support automatically fetching results, the action would ignore the `file` input and instead attempt to automatically fetch the results. The intention is for the `file` input to replace the automatic fetching.

Since we introduced two separate result schemas for Sonar (issues and hotspots), using local Sonar results includes more friction than other tools. When using `file`, the user must specify whether the local file is a Sonar issues file or Sonar security hotspots file.

/close #work