### PR TITLE
✨ Use New Unified Sonar Format

### DIFF
--- a/__tests__/action.test.ts
+++ b/__tests__/action.test.ts
@@ -74,7 +74,7 @@ describe("action", () => {
     getInputMock.mockImplementation((name: string) => {
       switch (name) {
         case "tool":
-          return "sonar_issues";
+          return "sonar";
         case "file":
           return "file.json";
         default:
@@ -109,7 +109,7 @@ describe("action", () => {
       getInputMock.mockImplementation((name: string) => {
         switch (name) {
           case "tool":
-            return "sonar_issues";
+            return "sonar";
           case "file":
             return "file.json";
           default:
@@ -120,7 +120,7 @@ describe("action", () => {
       await run();
 
       expect(uploadInputFileMock).toHaveBeenCalledWith(
-        "sonar_issues",
+        "sonar",
         new Array("file.json"),
       );
       expect(retrieveSonarIssuesMock).not.toHaveBeenCalled();

--- a/__tests__/pixee-platform.test.ts
+++ b/__tests__/pixee-platform.test.ts
@@ -38,10 +38,10 @@ describe("pixee-platform", () => {
       }
     });
 
-    await uploadInputFiles("sonar_issues", new Array(file.name));
+    await uploadInputFiles("sonar", new Array(file.name));
 
     expect(axios.put).toHaveBeenCalledWith(
-      "https://api.pixee.ai/analysis-input/owner/repo/sha/sonar_issues",
+      "https://api.pixee.ai/analysis-input/owner/repo/sha/sonar",
       expect.anything(), // cannot assert the form content
       {
         headers: {
@@ -68,10 +68,10 @@ describe("pixee-platform", () => {
       }
     });
 
-    await uploadInputFiles("sonar_issues", new Array(file1.name, file2.name));
+    await uploadInputFiles("sonar", new Array(file1.name, file2.name));
 
     expect(axios.put).toHaveBeenCalledWith(
-      "https://api.pixee.ai/analysis-input/owner/repo/sha/sonar_issues",
+      "https://api.pixee.ai/analysis-input/owner/repo/sha/sonar",
       expect.anything(), // cannot assert the form content
       {
         headers: {

--- a/src/action.ts
+++ b/src/action.ts
@@ -32,11 +32,6 @@ export async function run() {
   // if the file input is provided, upload the file
   const inputFile = core.getInput("file");
   if (inputFile) {
-    if (tool === "sonar") {
-      throw new Error(
-        `Tool "sonar" is too imprecise to use with a file input. Please use "sonar_issues" or "sonar_hotspots" instead.`,
-      );
-    }
     await uploadInputFiles(tool, new Array(inputFile));
     core.info(`Uploaded ${inputFile} for ${tool} to Pixeebot for analysis`);
   } else {
@@ -54,11 +49,11 @@ export async function run() {
         break;
       case "sonar":
         const issuesfiles = await fetchOrLocateSonarResultsFile("issues");
-        await uploadInputFiles("sonar_issues", issuesfiles);
+        await uploadInputFiles("sonar", issuesfiles);
         core.info(`Uploaded ${issuesfiles} to Pixeebot for analysis`);
 
         const hotspotFiles = await fetchOrLocateSonarResultsFile("hotspots");
-        await uploadInputFiles("sonar_hotspots", hotspotFiles);
+        await uploadInputFiles("sonar", hotspotFiles);
         core.info(`Uploaded ${hotspotFiles} to Pixeebot for analysis`);
         break;
       default:

--- a/src/inputs.ts
+++ b/src/inputs.ts
@@ -3,19 +3,6 @@ import { UserError } from "./errors";
 
 export type Tool =
   | "sonar"
-  | "sonar_issues"
-  | "sonar_hotspots"
-  | "codeql"
-  | "semgrep"
-  | "appscan"
-  | "defectdojo"
-  | "contrast"
-  | "checkmarx"
-  | "snyk";
-
-export type TOOL_PATH =
-  | "sonar_issues"
-  | "sonar_hotspots"
   | "codeql"
   | "semgrep"
   | "appscan"
@@ -47,8 +34,6 @@ function validateTool(tool: Tool) {
 
 const VALID_TOOLS: Tool[] = [
   "sonar",
-  "sonar_issues",
-  "sonar_hotspots",
   "codeql",
   "semgrep",
   "appscan",

--- a/src/pixee-platform.ts
+++ b/src/pixee-platform.ts
@@ -2,10 +2,10 @@ import * as core from "@actions/core";
 import axios from "axios";
 import fs from "fs";
 import FormData from "form-data";
-import { TOOL_PATH } from "./inputs";
+import { Tool } from "./inputs";
 import { getGitHubContext, getRepositoryInfo } from "./github";
 
-export async function uploadInputFiles(tool: TOOL_PATH, files: Array<string>) {
+export async function uploadInputFiles(tool: Tool, files: Array<string>) {
   const path = require("path");
   const pixeeUrl = core.getInput("pixee-api-url");
   const token = await core.getIDToken(pixeeUrl);
@@ -59,7 +59,7 @@ function buildTriggerApiUrl(prNumber: number): string {
   return `${pixeeUrl}/analysis-input/${owner}/${repo}/${prNumber}`;
 }
 
-function buildUploadApiUrl(tool: TOOL_PATH): string {
+function buildUploadApiUrl(tool: Tool): string {
   const { owner, repo, sha } = getGitHubContext();
   const pixeeUrl = core.getInput("pixee-api-url");
 


### PR DESCRIPTION
Users no long have to choose between formats "sonar_issues" and "sonar_hotspots". Both will work when sent as simply "sonar".